### PR TITLE
Fix clearing of agent list

### DIFF
--- a/com.unity.ml-agents/Runtime/Inference/ModelRunner.cs
+++ b/com.unity.ml-agents/Runtime/Inference/ModelRunner.cs
@@ -176,11 +176,11 @@ namespace TransformsAI.MicroMLAgents.Inference
             try
             {
                 agentList.Add(agent);
-
                 DecideBatch(agentList);
             }
             finally
             {
+                agentList.Clear();
                 Pool.Value.Push(agentList);
             }
         }


### PR DESCRIPTION
Pooled list was not cleared which resulted in agents with different observation specs being inferenced in the same batch